### PR TITLE
Update PR workflow: Remove auto-merge, user controls merging

### DIFF
--- a/.kiro/steering/pr-workflow.md
+++ b/.kiro/steering/pr-workflow.md
@@ -50,8 +50,18 @@ Ready for task X+1: [Next task description]
 - Example: `feature/visual-status-bars`
 
 ### After User Merges PR
-Only after user has merged the PR, return to main branch and pull latest:
+Only after user confirms the PR has been merged, clean up by:
+1. Return to main branch and pull latest changes:
 ```bash
 git checkout main
 git pull origin main
 ```
+2. Delete the local feature branch (if it still exists):
+```bash
+git branch -d feature/branch-name
+```
+
+### Cleanup Instructions
+- Wait for user to explicitly tell you "it's merged" or similar confirmation
+- Only then perform the cleanup steps above
+- This ensures we're always working from the latest main branch for the next task

--- a/.kiro/steering/pr-workflow.md
+++ b/.kiro/steering/pr-workflow.md
@@ -35,14 +35,12 @@ Ready for task X+1: [Next task description]
 1. Ensure all tests pass: `bundle exec cucumber && bundle exec rspec`
 2. Push branch: `git push origin feature-branch-name`
 3. Create PR: `gh pr create --title "Task Title" --body "Description"`
-4. Merge when ready: `gh pr merge --squash --delete-branch`
+4. **STOP** - Let user review and merge the PR
 
-### Auto-merge for Simple Tasks
-For straightforward implementations with passing tests:
-```bash
-gh pr create --title "Task Title" --body "Description"
-gh pr merge --squash --delete-branch
-```
+### Important Notes
+- **NEVER merge PRs automatically** - only the user should merge PRs
+- After creating PR, inform user it's ready for review
+- Wait for user to merge before proceeding to next task
 
 ## Branch Management
 
@@ -51,8 +49,8 @@ gh pr merge --squash --delete-branch
 - Example: `feature/create-basic-task`
 - Example: `feature/visual-status-bars`
 
-### After Merge
-Always return to main branch and pull latest:
+### After User Merges PR
+Only after user has merged the PR, return to main branch and pull latest:
 ```bash
 git checkout main
 git pull origin main


### PR DESCRIPTION
Updates the PR workflow steering document to clarify that:

## What's changed:
- ✅ Removed auto-merge instructions for Kiro
- ✅ Added clear note that only user should merge PRs
- ✅ Updated workflow to stop after PR creation
- ✅ Clarified that user controls the merge process

## Why:
User preference to maintain control over PR merging process rather than having Kiro auto-merge.

## Next steps:
This establishes the correct workflow going forward for all future PRs.