### PR TITLE
Fix PR #2 feedback: new tasks start as not done, remove unused file, add DB constraints

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,12 +1,4 @@
 class Task < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
   validates :interval_type, presence: true, inclusion: { in: %w[daily weekly monthly] }
-
-  before_create :set_initial_completion_time
-
-  private
-
-  def set_initial_completion_time
-    self.last_completed_at ||= Time.current
-  end
 end

--- a/app/views/tasks/create.html.erb
+++ b/app/views/tasks/create.html.erb
@@ -1,4 +1,0 @@
-<div>
-  <h1 class="font-bold text-4xl">Tasks#create</h1>
-  <p>Find me in app/views/tasks/create.html.erb</p>
-</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,5 @@ Rails.application.routes.draw do
   root "home#index"
 
   # Tasks
-  resources :tasks, only: [:new, :create, :index]
+  resources :tasks, only: [ :new, :create, :index ]
 end

--- a/db/migrate/20250720002537_add_not_null_constraints_to_tasks.rb
+++ b/db/migrate/20250720002537_add_not_null_constraints_to_tasks.rb
@@ -1,0 +1,6 @@
+class AddNotNullConstraintsToTasks < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :tasks, :name, false
+    change_column_null :tasks, :interval_type, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_19_235626) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_20_002537) do
   create_table "tasks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "name"
-    t.string "interval_type"
+    t.string "name", null: false
+    t.string "interval_type", null: false
     t.datetime "last_completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -26,11 +26,10 @@ RSpec.describe Task, type: :model do
     end
   end
 
-  describe "before_create callback" do
-    it "sets initial completion time" do
+  describe "initial state" do
+    it "starts as not completed" do
       task = Task.create!(name: "Test task", interval_type: "weekly")
-      expect(task.last_completed_at).to be_present
-      expect(task.last_completed_at).to be_within(1.second).of(Time.current)
+      expect(task.last_completed_at).to be_nil
     end
   end
 end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -22,5 +22,4 @@ RSpec.describe "Tasks", type: :request do
       expect(response).to have_http_status(:success)
     end
   end
-
 end


### PR DESCRIPTION
Addresses the feedback from PR #2 review comments.

## What's fixed:
- ✅ Removed  callback so new tasks start as NOT done (not completed)
- ✅ Deleted unused  file since we redirect after creation
- ✅ Added  database constraints to match Rails validations for required fields

## Testing:
- All Cucumber features still pass
- New tasks now correctly appear as not completed when created
- Database schema properly enforces required field constraints

## Next steps:
Ready to proceed with task 3 after this cleanup is merged.